### PR TITLE
Add check for subfield when field is of type cropimage

### DIFF
--- a/PageListImageLabel.module
+++ b/PageListImageLabel.module
@@ -101,7 +101,7 @@ class PageListImageLabel extends WireData implements Module,ConfigurableModule {
 				$size = explode(",", $options['pageLabelImageSize']);
 
 				// if image field is of type cropimage (thumbnails module)
-				if($this->fields->get($field)->type == "FieldtypeCropImage"){
+				if($this->fields->get($field)->type == "FieldtypeCropImage" && $subfield != ""){
 					if(count($v)){
 						$thumb_url = $v->first()->getThumb($subfield);
 						$thumb_url = $v->url . $this->resizeThumb($v, $thumb_url, $size);


### PR DESCRIPTION
Without this check, it wasn't possible to use the main image, rather than a specified crop - it would return a "There is no thumb called:" error when viewing the page tree.
