### PR TITLE
Add support for tags

### DIFF
--- a/PageListImageLabel.module
+++ b/PageListImageLabel.module
@@ -158,7 +158,20 @@ class PageListImageLabel extends WireData implements Module,ConfigurableModule {
 			} else { // all normal image fields
 
 				if($v instanceof Pageimages && count($v)) {
-					$thumb_url = $page->$field->first()->size($size[0],$size[1])->url;
+				
+					$tags_str = 'tags=';
+					
+					if(stripos($subfield, $tags_str) === 0) { // if subfield is a tag
+						$tag = str_replace($tags_str, '', $subfield);
+						// get first image with that tag
+						$thumb = $page->$field->getTag($tag);
+
+					} else { // get first image
+						$thumb = $page->$field->first();
+					}
+
+					if($thumb) $thumb_url = $thumb->size($size[0],$size[1])->url;
+					
 				} elseif($v instanceof Pageimage && $v) {
 					$thumb_url = $page->$field->size($size[0],$size[1])->url;
 				}


### PR DESCRIPTION
This change adds support for displaying the first image on the field that contains a given tag. 
It's used by adding the tags on the templates config in the following form: `template,field.tags=tag`

The form `field.tags=tag` is the one used by pw on the tags support in the API https://processwire.com/api/fieldtypes/images/ (scroll to "Using image tags"):
`$mypages = $pages->find("images.tags=sport");`